### PR TITLE
Update the fix-failing-checks prompt to explicitly not make Git commits

### DIFF
--- a/.github/workflows/fix-failing-checks.yml
+++ b/.github/workflows/fix-failing-checks.yml
@@ -94,7 +94,7 @@ jobs:
                 -   If it's a test failure, fix the code logic or update the test if the test is incorrect.
                 -   If it's a lint error, fix the style.
             4.  **Verify**: Ensure your changes are minimal and targeted.
-            5.  **Output**: Do not output the diff. Instead, write a concise summary of your changes to a markdown file named \`${summaryFile}\`. The format of the file should be as follows:
+            5.  **Output**: Do not output the diff and do NOT commit any changes to GitHub - you are running in a GitHub Action, which will handle committing your changes later. Instead, write a concise summary of your changes to a markdown file named \`${summaryFile}\`. The format of the file should be as follows:
 
             <summary-example>
             ## Tests Addressed

--- a/examples/fix-failing-checks.yml
+++ b/examples/fix-failing-checks.yml
@@ -107,7 +107,7 @@ jobs:
                 -   If it's a test failure, fix the code logic or update the test if the test is incorrect.
                 -   If it's a lint error, fix the style.
             4.  **Verify**: Ensure your changes are minimal and targeted.
-            5.  **Output**: Do not output the diff. Instead, write a concise summary of your changes to a markdown file named \`${summaryFile}\`. The format of the file should be as follows:
+            5.  **Output**: Do not output the diff and do NOT commit any changes to GitHub - you are running in a GitHub Action, which will handle committing your changes later. Instead, write a concise summary of your changes to a markdown file named \`${summaryFile}\`. The format of the file should be as follows:
 
             <summary-example>
             ## Tests Addressed


### PR DESCRIPTION
The fix-failing-checks agent will often try to commit directly to the branch when it makes a fix, which is not the behavior we want right now. Since we're handling the PR creation in the action outside of the agent's run, we don't want the agent to be taking any git actions here. 