### PR TITLE
Fix bash formatting for summary file detection

### DIFF
--- a/.github/workflows/fix-failing-checks.yml
+++ b/.github/workflows/fix-failing-checks.yml
@@ -142,7 +142,7 @@ jobs:
 
           # Get summary from file 
           SUMMARY_FILE="output_summary_$RUN_ID.md"
-          if [-f "$SUMMARY_FILE"]; then
+          if [ -f "$SUMMARY_FILE" ]; then
             SUMMARY_CONTENT=$(cat "$SUMMARY_FILE")
             # Clean up summary file so its not committed
             rm -f "$SUMMARY_FILE"

--- a/examples/fix-failing-checks.yml
+++ b/examples/fix-failing-checks.yml
@@ -157,7 +157,7 @@ jobs:
 
           # Get summary from file 
           SUMMARY_FILE="output_summary_$RUN_ID.md"
-          if [-f "$SUMMARY_FILE"]; then
+          if [ -f "$SUMMARY_FILE" ]; then
             SUMMARY_CONTENT=$(cat "$SUMMARY_FILE")
             # Clean up summary file so its not committed
             rm -f "$SUMMARY_FILE"


### PR DESCRIPTION
For the fix-failing-checks workflow, the summary file was not getting correctly used because of a bash formatting issue when we tried to detect the file. This PR fixes the formatting.
