### PR TITLE
Update the prompt for suggest-review-fixes to include example

### DIFF
--- a/.github/workflows/suggest-review-fixes.yml
+++ b/.github/workflows/suggest-review-fixes.yml
@@ -47,8 +47,8 @@ jobs:
           script: |
             const prompt = `You have a list of review comments in review_comments.json. For each comment:
             1. Determine if it's a small, straightforward fix (typos, naming, simple refactors, style issues).
-            2. If yes: propose a code suggestion (DO NOT modify files directly).
-            3. If no (too complex, requires design decisions, unclear): skip it.
+            2. If yes: propose a code suggestion (DO NOT modify files directly). This code suggestion will replace the part of the file included in the review comment, and only that diff hunk.
+            3. If no (too complex, requires design decisions, unclear, cannot be done in a single code suggestion): skip it.
 
             Output a file responses.json with this format:
             {
@@ -64,7 +64,7 @@ jobs:
 
             As an example:
             {
-              "12345678": "Updated the comment to address feedback, ```suggestion\n// New version of the comment here\n```"
+              "12345678": "Updated the print statement to address feedback, ```suggestion\nprintln!(New version of the print statement here)\n```"
             }
             `;
             core.setOutput('prompt', prompt);

--- a/examples/suggest-review-fixes.yml
+++ b/examples/suggest-review-fixes.yml
@@ -57,8 +57,8 @@ jobs:
           script: |
             const prompt = `You have a list of review comments in review_comments.json. For each comment:
             1. Determine if it's a small, straightforward fix (typos, naming, simple refactors, style issues).
-            2. If yes: propose a code suggestion (DO NOT modify files directly).
-            3. If no (too complex, requires design decisions, unclear): skip it.
+            2. If yes: propose a code suggestion (DO NOT modify files directly). This code suggestion will replace the part of the file included in the review comment, and only that diff hunk.
+            3. If no (too complex, requires design decisions, unclear, cannot be done in a single code suggestion): skip it.
 
             Output a file responses.json with this format:
             {
@@ -74,7 +74,7 @@ jobs:
 
             As an example:
             {
-              "12345678": "Updated the comment to address feedback, ```suggestion\n// New version of the comment here\n```"
+              "12345678": "Updated the print statement to address feedback, ```suggestion\nprintln!(New version of the print statement here)\n```"
             }
             `;
             core.setOutput('prompt', prompt);


### PR DESCRIPTION
The suggest-review-fixes workflow sometimes generated suggestions JSON files that were not formatted correctly. Here we include an explicit example of suggestion formatting.

The start_line part of the prompt is also not needed, as the `suggestion` functionality in GH comments doesn't use lines other than the ones provided by the comment—we always directly overwrite whatever was selected.
