### PR TITLE
Add newline before suggestion example

### DIFF
--- a/.github/workflows/suggest-review-fixes.yml
+++ b/.github/workflows/suggest-review-fixes.yml
@@ -64,7 +64,7 @@ jobs:
 
             As an example:
             {
-              "12345678": "Updated the print statement to address feedback, \`\`\`suggestion\nprintln!(New version of the print statement here)\n\`\`\`"
+              "12345678": "Updated the print statement to address feedback, \n\`\`\`suggestion\nprintln!(New version of the print statement here)\n\`\`\`"
             }
             `;
             core.setOutput('prompt', prompt);

--- a/examples/suggest-review-fixes.yml
+++ b/examples/suggest-review-fixes.yml
@@ -74,7 +74,7 @@ jobs:
 
             As an example:
             {
-              "12345678": "Updated the print statement to address feedback, \`\`\`suggestion\nprintln!(New version of the print statement here)\n\`\`\`"
+              "12345678": "Updated the print statement to address feedback, \n\`\`\`suggestion\nprintln!(New version of the print statement here)\n\`\`\`"
             }
             `;
             core.setOutput('prompt', prompt);


### PR DESCRIPTION
With the new example, sometimes the suggestions don't get formatted correctly to trigger the nice suggestion UI in the comment. Add a newline before the `suggestion` to the example.
