### PR TITLE
Downgrade to read permissions on suggest-review-fixes

### DIFF
--- a/.github/workflows/suggest-review-fixes.yml
+++ b/.github/workflows/suggest-review-fixes.yml
@@ -18,6 +18,10 @@ on:
 jobs:
   suggest_review_fixes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/examples/suggest-review-fixes.yml
+++ b/examples/suggest-review-fixes.yml
@@ -19,13 +19,13 @@ on:
   pull_request_review:
     types: [submitted]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   suggest_review_fixes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
For this workflow, the agent does not need `write` access to contents.
