### PR TITLE
Update example workflows to accept mcp/model/name

### DIFF
--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -11,6 +11,23 @@ on:
         required: false
         type: string
         default: ''
+      model:
+        description: Optional Warp model ID to use for Warp Agent.
+        required: false
+        type: string
+        default: ''
+      name:
+        description: Optional name for this agent task.
+        required: false
+        type: string
+        default: ''
+      mcp:
+        description:
+          Optional MCP configuration in JSON format (or a path to an mcp.json file) to start before
+          executing the agent.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Warp API key used by the Warp Agent.
@@ -84,6 +101,9 @@ jobs:
           prompt: ${{ steps.prompt.outputs.prompt }}
           warp_api_key: ${{ secrets.WARP_API_KEY }}
           profile: ${{ inputs.profile || vars.WARP_AGENT_PROFILE || '' }}
+          model: ${{ inputs.model || vars.WARP_AGENT_MODEL || '' }}
+          name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
+          mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
       - name: Create PR and Comment
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/daily-issue-summary.yml
+++ b/.github/workflows/daily-issue-summary.yml
@@ -11,6 +11,23 @@ on:
         required: false
         type: string
         default: ''
+      model:
+        description: Optional Warp model ID to use for Warp Agent.
+        required: false
+        type: string
+        default: ''
+      name:
+        description: Optional name for this agent task.
+        required: false
+        type: string
+        default: ''
+      mcp:
+        description:
+          Optional MCP configuration in JSON format (or a path to an mcp.json file) to start before
+          executing the agent.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Warp API key used by the Warp Agent.
@@ -109,6 +126,9 @@ jobs:
           prompt: ${{ steps.prompt.outputs.prompt }}
           warp_api_key: ${{ secrets.WARP_API_KEY }}
           profile: ${{ inputs.profile || vars.WARP_AGENT_PROFILE || '' }}
+          model: ${{ inputs.model || vars.WARP_AGENT_MODEL || '' }}
+          name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
+          mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
       - name: Post to Slack
         if: steps.fetch_issues.outputs.has_issues == 'true'
         env:

--- a/.github/workflows/fix-failing-checks.yml
+++ b/.github/workflows/fix-failing-checks.yml
@@ -11,6 +11,23 @@ on:
         required: false
         type: string
         default: ''
+      model:
+        description: Optional Warp model ID to use for Warp Agent.
+        required: false
+        type: string
+        default: ''
+      name:
+        description: Optional name for this agent task.
+        required: false
+        type: string
+        default: ''
+      mcp:
+        description:
+          Optional MCP configuration in JSON format (or a path to an mcp.json file) to start before
+          executing the agent.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Warp API key used by the Warp Agent.
@@ -122,6 +139,9 @@ jobs:
           prompt: ${{ steps.prompt.outputs.prompt }}
           warp_api_key: ${{ secrets.WARP_API_KEY }}
           profile: ${{ inputs.profile || vars.WARP_AGENT_PROFILE || '' }}
+          model: ${{ inputs.model || vars.WARP_AGENT_MODEL || '' }}
+          name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
+          mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
       - name: Create Fix PR
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/respond-to-comment.yml
+++ b/.github/workflows/respond-to-comment.yml
@@ -11,6 +11,23 @@ on:
         required: false
         type: string
         default: ''
+      model:
+        description: Optional Warp model ID to use for Warp Agent.
+        required: false
+        type: string
+        default: ''
+      name:
+        description: Optional name for this agent task.
+        required: false
+        type: string
+        default: ''
+      mcp:
+        description:
+          Optional MCP configuration in JSON format (or a path to an mcp.json file) to start before
+          executing the agent.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Warp API key used by the Warp Agent.
@@ -150,6 +167,9 @@ jobs:
           warp_api_key: ${{ secrets.WARP_API_KEY }}
           profile: ${{ inputs.profile || vars.WARP_AGENT_PROFILE || '' }}
           output_format: json
+          model: ${{ inputs.model || vars.WARP_AGENT_MODEL || '' }}
+          name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
+          mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
       - name: Commit and Push Changes
         if: success()
         env:

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -11,6 +11,23 @@ on:
         required: false
         type: string
         default: ''
+      model:
+        description: Optional Warp model ID to use for Warp Agent.
+        required: false
+        type: string
+        default: ''
+      name:
+        description: Optional name for this agent task.
+        required: false
+        type: string
+        default: ''
+      mcp:
+        description:
+          Optional MCP configuration in JSON format (or a path to an mcp.json file) to start before
+          executing the agent.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Warp API key used by the Warp Agent.
@@ -134,6 +151,9 @@ jobs:
           prompt: ${{ steps.prompt.outputs.prompt }}
           warp_api_key: ${{ secrets.WARP_API_KEY }}
           profile: ${{ inputs.profile || vars.WARP_AGENT_PROFILE || '' }}
+          model: ${{ inputs.model || vars.WARP_AGENT_MODEL || '' }}
+          name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
+          mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
       - name: Post Review
         uses: actions/github-script@v7
         if: always()

--- a/.github/workflows/suggest-review-fixes.yml
+++ b/.github/workflows/suggest-review-fixes.yml
@@ -11,6 +11,23 @@ on:
         required: false
         type: string
         default: ''
+      model:
+        description: Optional Warp model ID to use for Warp Agent.
+        required: false
+        type: string
+        default: ''
+      name:
+        description: Optional name for this agent task.
+        required: false
+        type: string
+        default: ''
+      mcp:
+        description:
+          Optional MCP configuration in JSON format (or a path to an mcp.json file) to start before
+          executing the agent.
+        required: false
+        type: string
+        default: ''
     secrets:
       WARP_API_KEY:
         description: Warp API key used by the Warp Agent.
@@ -78,6 +95,9 @@ jobs:
           warp_api_key: ${{ secrets.WARP_API_KEY }}
           profile: ${{ inputs.profile || vars.WARP_AGENT_PROFILE || '' }}
           prompt: ${{ steps.prompt.outputs.prompt }}
+          model: ${{ inputs.model || vars.WARP_AGENT_MODEL || '' }}
+          name: ${{ inputs.name || vars.WARP_AGENT_NAME || '' }}
+          mcp: ${{ inputs.mcp || vars.WARP_AGENT_MCP || '' }}
       - name: Reply to comments
         uses: actions/github-script@v7
         if: always()

--- a/consumer-workflows/auto-fix-issue.yml
+++ b/consumer-workflows/auto-fix-issue.yml
@@ -30,6 +30,10 @@ jobs:
   auto_fix:
     uses: warpdotdev/warp-agent-action/.github/workflows/auto-fix-issue.yml@v1
     with:
+      # These inputs are all optional
       profile: ''
+      model: ''
+      name: ''
+      mcp: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/consumer-workflows/daily-issue-summary.yml
+++ b/consumer-workflows/daily-issue-summary.yml
@@ -29,7 +29,11 @@ jobs:
   summarize_issues:
     uses: warpdotdev/warp-agent-action/.github/workflows/daily-issue-summary.yml@v1
     with:
+      # These inputs are all optional
       profile: ''
+      model: ''
+      name: ''
+      mcp: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/consumer-workflows/fix-failing-checks.yml
+++ b/consumer-workflows/fix-failing-checks.yml
@@ -31,6 +31,10 @@ jobs:
   fix_failure:
     uses: warpdotdev/warp-agent-action/.github/workflows/fix-failing-checks.yml@v1
     with:
+      # These inputs are all optional
       profile: ''
+      model: ''
+      name: ''
+      mcp: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/consumer-workflows/respond-to-comment.yml
+++ b/consumer-workflows/respond-to-comment.yml
@@ -32,6 +32,10 @@ jobs:
   respond:
     uses: warpdotdev/warp-agent-action/.github/workflows/respond-to-comment.yml@v1
     with:
+      # These inputs are all optional
       profile: ''
+      model: ''
+      name: ''
+      mcp: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/consumer-workflows/review-pr.yml
+++ b/consumer-workflows/review-pr.yml
@@ -31,6 +31,10 @@ jobs:
   review_pr:
     uses: warpdotdev/warp-agent-action/.github/workflows/review-pr.yml@v1
     with:
+      # These inputs are all optional
       profile: ''
+      model: ''
+      name: ''
+      mcp: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/consumer-workflows/suggest-review-fixes.yml
+++ b/consumer-workflows/suggest-review-fixes.yml
@@ -28,6 +28,10 @@ jobs:
   suggest_review_fixes:
     uses: warpdotdev/warp-agent-action/.github/workflows/suggest-review-fixes.yml@v1
     with:
+      # These inputs are all optional
       profile: ''
+      model: ''
+      name: ''
+      mcp: ''
     secrets:
       WARP_API_KEY: ${{ secrets.WARP_API_KEY }}


### PR DESCRIPTION
### TL;DR

Added additional configuration options for Warp Agent in all GitHub workflows.

### What changed?

- Added three new input parameters to all workflow files:
  - `model`: Optional Warp model ID to use for Warp Agent
  - `name`: Optional name for this agent task
  - `mcp`: Optional MCP configuration in JSON format (or path to an mcp.json file)
- Updated all workflow steps that use the Warp Agent to pass these new parameters
- Modified the build script to include these new parameters in generated workflows
- Added comments in consumer templates to indicate that all inputs are optional

### How to test?

1. Use any of the workflows with the new parameters:
```yaml
jobs:
  review_pr:
    uses: warpdotdev/warp-agent-action/.github/workflows/review-pr.yml@v1
    with:
      profile: 'my-profile'
      model: 'my-model-id'
      name: 'PR Review Task'
      mcp: '{"config": "value"}'
    secrets:
      WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
```

2. Alternatively, set repository variables (WARP_AGENT_MODEL, WARP_AGENT_NAME, WARP_AGENT_MCP) to provide default values for these parameters.

### Why make this change?

These additional parameters provide more flexibility and control over Warp Agent execution in GitHub workflows. Users can now specify which model to use, provide a descriptive name for the task, and configure MCP settings, enabling more customized and powerful automation scenarios.